### PR TITLE
Add enable_multithread=True

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ deploy:
     secure: d+RIBeI8E66mLPZan5vgEYR5P4K+J8YfcAJR16MFVuoKkvMaCze+Ho5bFgUzN47wW+SzAjFixPI4fkB4Silk+7BCwMeQrBQq+CL9OYCZf2vPwl2K3QTScwVCreEF05u3V1x5lm3/UvzTAuz0knaXwrWelRm5DOVf3DZPjWEcXtA=
   on:
     tags: true
-    repo: lins05/slackbot
+    repo: amuraru/slackbot

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-[![PyPI](https://badge.fury.io/py/slackbot.svg)](https://pypi.python.org/pypi/slackbot) [![Build Status](https://secure.travis-ci.org/lins05/slackbot.svg?branch=master)](http://travis-ci.org/lins05/slackbot)
+[![PyPI](https://badge.fury.io/py/slackbot.svg)](https://pypi.python.org/pypi/slackbotng) 
+[![Build Status](https://secure.travis-ci.org/amuraru/slackbotng.svg?branch=devel)](http://travis-ci.org/amuraru/slackbotng)
 
-A chat bot for [Slack](https://slack.com) inspired by [llimllib/limbo](https://github.com/llimllib/limbo) and [will](https://github.com/skoczen/will).
+A chat bot for [Slack](https://slack.com) inspired by [llimllib/limbo](https://github.com/llimllib/limbo) and [will](https://github.com/skoczen/will).  
+This is a fork of [lins05/slackbot](https://github.com/lins05/slackbot) with the package name being renamed to `slackbotng` due to the lack of the activity from the original author.
+All credits go to `Shuai Lin` for the initial implementation.
 
 ## Features
 
@@ -15,7 +18,7 @@ A chat bot for [Slack](https://slack.com) inspired by [llimllib/limbo](https://g
 
 
 ```
-pip install slackbot
+pip install slackbotng
 ```
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,4 @@ setup(name='slackbotng',
                    'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.4',
-                   'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6'])

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,13 @@ excludes = (
     '*local_settings*',
 ) # yapf: disable
 
-setup(name='slackbot',
+setup(name='slackbotng',
       version=__version__,
       license='MIT',
       description='A simple chat bot for Slack',
-      author='Shuai Lin',
-      author_email='linshuai2012@gmail.com',
-      url='http://github.com/lins05/slackbot',
+      author='Adrian Muraru',
+      author_email='adi.muraru@gmail.com',
+      url='http://github.com/amuraru/slackbot',
       platforms=['Any'],
       packages=find_packages(exclude=excludes),
       install_requires=install_requires,

--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -19,6 +19,8 @@ class Bot(object):
     def __init__(self):
         self._client = SlackClient(
             settings.API_TOKEN,
+            timeout=settings.TIMEOUT if hasattr(settings,
+                                                'TIMEOUT') else None,
             bot_icon=settings.BOT_ICON if hasattr(settings,
                                                   'BOT_ICON') else None,
             bot_emoji=settings.BOT_EMOJI if hasattr(settings,

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -10,6 +10,11 @@ PLUGINS = [
 
 ERRORS_TO = None
 
+'''
+Setup timeout for slacker API requests (e.g. uploading a file).
+'''
+TIMEOUT = 100
+
 # API_TOKEN = '###token###'
 
 '''

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class SlackClient(object):
-    def __init__(self, token, bot_icon=None, bot_emoji=None, connect=True):
+    def __init__(self, token, timeout=None, bot_icon=None, bot_emoji=None, connect=True):
         self.token = token
         self.bot_icon = bot_icon
         self.bot_emoji = bot_emoji
@@ -31,7 +31,10 @@ class SlackClient(object):
         self.users = {}
         self.channels = {}
         self.connected = False
-        self.webapi = slacker.Slacker(self.token)
+        if timeout is None:
+            self.webapi = slacker.Slacker(self.token)
+        else:
+            self.webapi = slacker.Slacker(self.token, timeout=timeout)
 
         if connect:
             self.rtm_connect()

--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -70,7 +70,8 @@ class SlackClient(object):
             no_proxy = os.environ['no_proxy']
 
         self.websocket = create_connection(self.login_data['url'], http_proxy_host=proxy,
-                                           http_proxy_port=proxy_port, http_no_proxy=no_proxy)
+                                           http_proxy_port=proxy_port, http_no_proxy=no_proxy,
+                                           enable_multithread=True)
 
         self.websocket.sock.setblocking(0)
 

--- a/tests/functional/driver.py
+++ b/tests/functional/driver.py
@@ -194,7 +194,7 @@ class Driver(object):
         self.users = {u['name']: u['id'] for u in r['users']}
         self.testbot_userid = self.users[self.testbot_username]
 
-        self._websocket = websocket.create_connection(r['url'])
+        self._websocket = websocket.create_connection(r['url'], enable_multithread=True)
         self._websocket.sock.setblocking(0)
         _thread.start_new_thread(self._rtm_read_forever, tuple())
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py36
 [testenv]
 deps =
     pytest


### PR DESCRIPTION
Add param enable_multithread=True for create_connection call.

As per documentation for create_connection function:
"enable_multithread" -> enable lock for multithread.

create_connection returns a WebSocket object for which enable_multithread defaults to False.
As per documentation for WebSocket class:
enable_multithread: if set to True, lock send method.