### PR TITLE
Fix TypeError on using WebClient.files_upload.

### DIFF
--- a/slackbot/slackclient.py
+++ b/slackbot/slackclient.py
@@ -152,14 +152,15 @@ class SlackClient(object):
     def upload_file(self, channel, fname, fpath, comment, thread_ts=None):
         channel = self._channelify(channel)
         fname = fname or os.path.basename(fpath)
-        return self.webapi.files_upload(fpath,
+        return self.webapi.files_upload(
+                                 file=fpath,
                                  channels=channel,
                                  filename=fname,
                                  initial_comment=comment,
                                  thread_ts=thread_ts)
 
     def upload_content(self, channel, fname, content, comment, thread_ts=None):
-        return self.webapi.files_upload(None,
+        return self.webapi.files_upload(
                                  channels=channel,
                                  content=content,
                                  filename=fname,


### PR DESCRIPTION
First of all, thank you for nice project.
I recently started to use slackbotng and I'd like to merge this patch to fix TypeError on using WebClient.files_upload if possible.
Could you consider merging this change?